### PR TITLE
Disable Travis CI IRC notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,12 +83,12 @@ script:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then mk/macos/build-mg.sh -c 4; fi
 
 # https://docs.travis-ci.com/user/notifications/#IRC-notification
-notifications:
-  irc:
-    channels:
-      - "irc.freenode.org#megaglest"
-    skip_join: true
-    use_notice: true
-    on_success: change
-    template:
-      - "[%{repository_name}#%{branch}@%{commit}] %{author}: %{message} %{build_url}"
+#notifications:
+#  irc:
+#    channels:
+#      - "irc.freenode.org#megaglest"
+#    skip_join: true
+#    use_notice: true
+#    on_success: change
+#    template:
+#      - "[%{repository_name}#%{branch}@%{commit}] %{author}: %{message} %{build_url}"


### PR DESCRIPTION
Currently, Travis CI build failures are reported to IRC (Freenode, #megaglest). Disable them for now for this fork.